### PR TITLE
Correção no imprimir lista de abreviaturas

### DIFF
--- a/documento.tex
+++ b/documento.tex
@@ -163,7 +163,7 @@
 	\imprimirlistadequadros
 	\imprimirlistadealgoritmos
 	\imprimirlistadecodigosfonte
-	\imprimirlistadeabreviaturasesiglas	
+	\imprimirlistadeabreviaturasesiglas-
 	\imprimirlistadesimbolos{elementos-pre-textuais/lista-de-simbolos}   
 	\imprimirsumario
 	


### PR DESCRIPTION
Lista de abreviaturas e siglas não é renderizada sem o hífen ao fim do comando \imprimirlistadeabreviaturasesiglas