### PR TITLE
Alinhar referências à esquerda

### DIFF
--- a/lib/preambulo.tex
+++ b/lib/preambulo.tex
@@ -55,7 +55,7 @@
 \usepackage{etoolbox}                               % Usado para alterar a fonte da Section no Sumário
 \usepackage[nogroupskip,nonumberlist,acronym]{glossaries}                % Permite fazer o glossario
 \usepackage{caption}                                % Altera o comportamento da tag caption
-\usepackage[alf, abnt-emphasize=bf, bibjustif, recuo=0cm, abnt-etal-cite=3, abnt-etal-list=0, abnt-etal-text=it, abnt-thesis-year=both]{abntex2cite}  % Citações padrão ABNT
+\usepackage[alf, abnt-emphasize=bf, recuo=0cm, abnt-etal-cite=3, abnt-etal-list=0, abnt-etal-text=it, abnt-thesis-year=both]{abntex2cite}  % Citações padrão ABNT
 %\usepackage[bottom]{footmisc}                      % Mantém as notas de rodapé sempre na mesma posição
 %\usepackage{times}                                 % Usa a fonte Times
 \usepackage{mathptmx}                               % Usa a fonte Times New Roman										


### PR DESCRIPTION
Para alinhar as referências à esquerda, como define o Guia da UECE,  removi o bibjustif do pacote abntex2cite.